### PR TITLE
Speed Fix

### DIFF
--- a/LiquidBounce/settings/hypixel
+++ b/LiquidBounce/settings/hypixel
@@ -207,7 +207,7 @@ Tower JumpDelay 4
 Sneak Mode Legit
 Sneak StopMove true
 
-Speed Mode HypixelHop
+Speed Mode NCPFHop
 
 Sprint AllDirections true
 Sprint Blindness true


### PR DESCRIPTION
This Speed Mode is great working, "HypixelHop" speed is banning sometimes.
Is great working in skywars, bedwars, blitz sg, murder mystery and all.
I don't wanted update the config update date, i hope Marco or Senk Ju will add the Update Date.

If Marco will merge the pull request, i have a suggestion for liquidbounce: FIX HYPIXELHOP SPEED