### PR TITLE
Updated the HiveMC config

### DIFF
--- a/LiquidBounce/settings/hivemc
+++ b/LiquidBounce/settings/hivemc
@@ -70,7 +70,7 @@ BowAimbot ThroughWalls false
 BowAimbot PredictSize 2.0
 BowAimbot Priority Direction
 BowAimbot Mark true
-BufferSpeed SpeedLimit true
+BufferSpeedLimit true
 BufferSpeed MaxSpeed 2.0
 BufferSpeed Buffer true
 BufferSpeed Stairs true
@@ -272,7 +272,7 @@ Kick Mode Quit
 KillAura MaxCPS 12
 KillAura MinCPS 8
 KillAura HurtTime 10
-KillAura Range 5.75
+KillAura Range 5.0
 KillAura ThroughWallsRange 4.0
 KillAura RangeSprintReducement 0.4
 KillAura Priority Distance
@@ -380,7 +380,7 @@ SlimeJump Motion 1.0
 SlimeJump Mode Add
 Sneak Mode Legit
 Sneak StopMove false
-Speed Mode AAC5BHop
+Speed Mode AACLowHop3
 Speed CustomSpeed 0.2
 Speed CustomY 0.4
 Speed CustomTimer 1.16
@@ -486,7 +486,7 @@ Sprint Toggle true
 TPHit Toggle true
 InventoryMove Toggle true
 ChestStealer Toggle true
-InventoryCleaner Toggle true
+InventoryCleaner Toggle false
 PingSpoof Toggle true
 Criticals Toggle false
 WaterSpeed Toggle true


### PR DESCRIPTION
Killaura range reduced because it doesnt hit anything further than Range 5, AACLowHop3 doesnt gets flagged FAR less than AAC3Bhop. 
Also if loaded in the lobby InventoryCleaner is annoying.