### PR TITLE
epic

### DIFF
--- a/LiquidBounce/settings/cubecraft-1.12
+++ b/LiquidBounce/settings/cubecraft-1.12
@@ -1,4 +1,6 @@
 load https://raw.githubusercontent.com/CCBlueX/LiquidCloud/master/LiquidBounce/settings/cubecraft
+# sentinel 1.9 don't check aura mode
+killaura targetmode multi
 killaura range 3.6
 cheststealer mindelay 140
 cheststealer maxdelay 160


### PR DESCRIPTION
so cubecraft 1.9 don't check aura target mode ... (tested in another clients and lb 1.12.2 Build2)