### PR TITLE
Corrected jigsaw client url

### DIFF
--- a/LiquidBounce/credits.json
+++ b/LiquidBounce/credits.json
@@ -37,7 +37,7 @@
         "TwitterURL": "https://twitter.com/JigsawClient",
         "YouTubeName": "Robofån",
         "YouTubeURL": "https://www.youtube.com/channel/UCtYz3npCasN6oMAWSX1_etQ",
-        "Website": "https://jigsawclient.ml",
+        "Website": "https://jigsawclient.net",
         "Credits": {
             "0": "Helped us with a XRay Bug."
         }


### PR DESCRIPTION
jigsawclient.ml —> jigsawclient.net