### PR TITLE
Hypixel settings auto .panic nonrender and changes for chat messages

### DIFF
--- a/LiquidBounce/settings/hypixel
+++ b/LiquidBounce/settings/hypixel
@@ -1,5 +1,124 @@
 # AutoSettings for Hypixel
-# 20/05/2021
+# 17/08/2021
+
+# Panic NonRender
+AbortBreaking toggle false
+Aimbot toggle false
+AirJump toggle false
+AirLadder toggle false
+AntiAFK toggle false
+AntiBot toggle false
+AntiCactus toggle false
+AntiHunger toggle false
+AtAllProvider toggle false
+AutoArmor toggle false
+AutoBow toggle false
+AutoBreak toggle false
+AutoClicker toggle false
+AutoFish toggle false
+AutoLeave toggle false
+AutoPot toggle false
+AutoRespawn toggle false
+AutoSoup toggle false
+AutoTool toggle false
+AutoWalk toggle false
+AutoWeapon toggle false
+BedGodMode toggle false
+Blink toggle false
+BlockWalk toggle false
+BowAimbot toggle false
+BufferSpeed toggle false
+BugUp toggle false
+ChestAura toggle false
+ChestStealer toggle false
+CivBreak toggle false
+Clip toggle false
+ComponentOnHover toggle false
+ConsoleSpammer toggle false
+Criticals toggle false
+Damage toggle false
+Derp toggle false
+Eagle toggle false
+FastBow toggle false
+FastBreak toggle false
+FastClimb toggle false
+FastPlace toggle false
+FastStairs toggle false
+FastUse toggle false
+Fly toggle false
+ForceUnicodeChat toggle false
+Freeze toggle false
+Fucker toggle false
+Ghost toggle false
+GhostHand toggle false
+GodMode toggle false
+HighJump toggle false
+HitBox toggle false
+IceSpeed toggle false
+Ignite toggle false
+InventoryCleaner toggle false
+InventoryMove toggle false
+ItemTeleport toggle false
+KeepAlive toggle false
+KeepContainer toggle false
+Kick toggle false
+KillAura toggle false
+LadderJump toggle false
+LiquidChat toggle false
+LiquidWalk toggle false
+Liquids toggle false
+LongJump toggle false
+MidClick toggle false
+MoreCarry toggle false
+MultiActions toggle false
+NameProtect toggle false
+NoClip toggle false
+NoFall toggle false
+NoFriends toggle false
+NoJumpDelay toggle false
+NoPitchLimit toggle false
+NoRotateSet toggle false
+NoSlow toggle false
+NoSlowBreak toggle false
+NoWeb toggle false
+Nuker toggle false
+Parkour toggle false
+PerfectHorseJump toggle false
+Phase toggle false
+PingSpoof toggle false
+Plugins toggle false
+PortalMenu toggle false
+PotionSaver toggle false
+Reach toggle false
+Regen toggle false
+ResourcePackSpoof toggle false
+ReverseStep toggle false
+SafeWalk toggle false
+Scaffold toggle false
+ServerCrasher toggle false
+SkinDerp toggle false
+SlimeJump toggle false
+Sneak toggle false
+Spammer toggle false
+Speed toggle false
+Sprint toggle false
+Step toggle false
+Strafe toggle false
+SuperKnockback toggle false
+TNTBlock toggle false
+Teams toggle false
+Teleport toggle false
+TeleportHit toggle false
+Timer toggle false
+Tower toggle false
+Trigger toggle false
+VehicleOneHit toggle false
+Velocity toggle false
+WallClimb toggle false
+WaterSpeed toggle false
+Zoot toggle false
+
+
 
 AntiBot Tab true
 AntiBot TabMode Contains
@@ -270,8 +389,6 @@ targetInvisible false
 targetDead false
 
 # Chat
-unchat &r
-unchat &c&lWARNING! &bPlease execute .panic nonrender before loading settings!
 unchat &r
 unchat &r
 unchat &r                   &7→ &c&lHYPIXEL SETTINGS &7| &b17/08/2021 &7←

--- a/LiquidBounce/settings/hypixel
+++ b/LiquidBounce/settings/hypixel
@@ -270,18 +270,14 @@ targetInvisible false
 targetDead false
 
 # Chat
+unchat &r
 unchat &c&lWARNING! &bPlease execute .panic nonrender before loading settings!
 unchat &r
 unchat &r
-unchat &r
-unchat &r
-unchat &r
-unchat &r                   &7→ &c&lHYPIXEL SETTINGS &7| &b27/06/2020 &7←
+unchat &r                   &7→ &c&lHYPIXEL SETTINGS &7| &b17/08/2021 &7←
 unchat &r                &3&lTower &a, &3&lStep &a& &3&lNoFall are bypassing fine!
 unchat &r          &aCheck out the Fly Script: &e&lhttps://forum.ccbluex.net/thread.php?id=3123
 unchat &r            &cDo not use Fly, LongJump, packet criticals or other step than jump!
 unchat &r               &aNote: &cThis settings are made for LiquidBounce Build72
 unchat &r                &cBypasses seem to be semi-patched. Use at your own risk
-unchat &r
-unchat &r                     &aJOIN US: &3https://discord.gg/gdQ82He
 unchat &r


### PR DESCRIPTION
removed discord link because:
![grafik](https://user-images.githubusercontent.com/27882680/129688693-cbcc2d83-e25c-4768-95f7-d8df4e99af57.png)

And the warning `WARNING! &bPlease execute .panic nonrender before loading settings!` was removed because it isn't necessary anymore.