### PR TITLE
fix: fix:blocksmc

### DIFF
--- a/LiquidBounce/settings/nextgen/blocksmc.json
+++ b/LiquidBounce/settings/nextgen/blocksmc.json
@@ -7628,7 +7628,7 @@
           "value": [
             {
               "name": "Enabled",
-              "value": false
+              "value": true
             },
             {
               "name": "SlowSpeed",
@@ -7653,8 +7653,8 @@
             {
               "name": "DiagonalSpeed",
               "value": {
-                "from": 0.43,
-                "to": 0.43
+                "from": 0.24,
+                "to": 0.24
               }
             }
           ]


### PR DESCRIPTION
dont eva buy no config from the gas station

fix: scaffold flagging, because someone changed the scaffold settings to their own