### PR TITLE
some fixes to my prev mcci config mccisland.json

### DIFF
--- a/LiquidBounce/settings/nextgen/mccisland.json
+++ b/LiquidBounce/settings/nextgen/mccisland.json
@@ -15171,7 +15171,7 @@
                     },
                     {
                       "name": "ResetMode",
-                      "value": "Reset"
+                      "value": "Reverse"
                     },
                     {
                       "name": "Straight",
@@ -15200,7 +15200,7 @@
                   "value": [
                     {
                       "name": "Enabled",
-                      "value": true
+                      "value": false
                     }
                   ]
                 },
@@ -15271,7 +15271,7 @@
         },
         {
           "name": "Tower",
-          "active": "None",
+          "active": "Karhu",
           "value": [],
           "choices": {
             "None": {


### PR DESCRIPTION
tower set to karhu on default to actually allow people to jump. (also no movement stabilising, it causes u to fall off, and reverse just goes faster)