### PR TITLE
创建布吉岛配置

### DIFF
--- a/LiquidBounce/settings/nextgen/BuJiIsland.json
+++ b/LiquidBounce/settings/nextgen/BuJiIsland.json
@@ -25904,7 +25904,7 @@
           "clientVersion": "0.30.0",
           "clientCommit": "git-4f0aa0f",
           "serverAddress": "127.0.0.1:6445",
-          "protocolName": "1.20.1",
+          "protocolName": "1.20-1.20.1",
           "protocolVersion": 769,
           "type": "Rage",
           "status": "Bypassing",


### PR DESCRIPTION
Created config for Chinese server BuJiIsland.
Down goes notices:
如果提示CPS过高,把Kill Aura的CPS调到6或以下，按P开关ESP，退格偷箱子（没用），K杀戮， ]长按自动搭桥，回车Safe Walk其他的按键自行探索。警告：不要在布吉岛里面探索，否则封号了别怪我，出了布吉岛再试其他快捷键，而且我不保证他们的稳定性，最好别试！！！本配置仅供参考学习，“不要实操”！！