### PR TITLE
feat: add MMC Modern config

### DIFF
--- a/LiquidBounce/settings/nextgen/mmc-modern.json
+++ b/LiquidBounce/settings/nextgen/mmc-modern.json
@@ -20613,7 +20613,7 @@
       }
     ]
   },
-  "author": "LefordMC",
+  "author": "DataM0del",
   "date": "21/11/2025",
   "time": "18:04:54",
   "clientVersion": "0.35.2",
@@ -20622,5 +20622,10 @@
   "protocolName": "1.20.5-1.20.6",
   "protocolVersion": 766,
   "type": "Rage",
-  "status": "Bypassing"
+  "status": "Bypassing",
+  "chat": [
+    "Constant FakeLag is to make the Velocity less annoying when moving",
+    "AntiHunger is to prevent the client sending sprint packets in order to let you omnisprint",
+    "This config will NOT work on Legacy MMC (1.8.x), even if you use modern versions. (probably AutoClicker flags and reach)"
+  ]
 }


### PR DESCRIPTION
this will definitely flag autoclicker on the Legacy server lol, but it works perfect on the modern server with 1.20.6 ViaFabricPlus. I got a 56 winstreak with this before my connection started breaking (staff?, a while ago I was using this config and staff decided to troll me and cancel all my hits... and then I rejoined, and then I could hit again.)